### PR TITLE
Initial loading change

### DIFF
--- a/generators/app/templates/src/app/screens.ejs
+++ b/generators/app/templates/src/app/screens.ejs
@@ -3,7 +3,13 @@
 //  in favour of setting the initialRoute as a prop of the navigator
 
 <%_ if(features.drawerandroid || features.drawerios) { _%>
+<%_ if(features.login) { _%>
 import React, { PureComponent } from 'react';
+<%_ } else { _%>
+import React from 'react';
+<%_ } _%>
+<%_ } else if(features.login) { _%>
+import { PureComponent } from 'react';
 <%_ } _%>
 <%_ if(features.login) { _%>
 import { connect } from 'react-redux';
@@ -58,6 +64,7 @@ const InitialLoadingScreenContainer = connect(loadingScreenMapStateToProps)(Init
 <%_ } _%>
 export default StackNavigator({
   <%_ if (features.login) { _%>
+  InitialLoading: { screen: InitialLoadingScreenContainer },
   Login: {
     screen: Login,
     navigationOptions: {
@@ -84,7 +91,7 @@ export default StackNavigator({
       <%_ } _%>
       title: 'Home'
     })
-  },
+  }
   <%_ } else { _%>
   Home: {
     screen: Home,
@@ -96,9 +103,8 @@ export default StackNavigator({
       <%_ } _%>
       title: 'Home'
     })
-  },
+  }
   <%_ } _%>
-  InitialLoading: { screen: InitialLoadingScreenContainer }
   <%_ } else if (features.tabs) { _%>
   Home: {
     screen: TabNavigator({

--- a/generators/app/templates/src/app/screens.ejs
+++ b/generators/app/templates/src/app/screens.ejs
@@ -3,7 +3,7 @@
 //  in favour of setting the initialRoute as a prop of the navigator
 
 <%_ if(features.drawerandroid || features.drawerios) { _%>
-import React from 'react';
+import React, { PureComponent } from 'react';
 <%_ } _%>
 <%_ if(features.login) { _%>
 import { connect } from 'react-redux';
@@ -27,17 +27,21 @@ import Home from './screens/home';
 
 <%_ if(features.login) { _%>
 // ------------------ Initial loading screen
-const InitialLoadingScreen = props => {
-  if (!props.initialLoading) {
-    props.dispatch(
-      NavigationActions.reset({
-        index: 0,
-        actions: [NavigationActions.navigate({ routeName: props.currentUser ? 'Home' : 'Login' })]
-      })
-    );
+class InitialLoadingScreen extends PureComponent {
+  componentWillReceiveProps(nextProps) {
+    if (!nextProps.initialLoading) {
+      nextProps.dispatch(
+        NavigationActions.reset({
+          index: 0,
+          actions: [NavigationActions.navigate({ routeName: nextProps.currentUser ? 'Home' : 'Login' })]
+        })
+      );
+    }
   }
-  return null;
-};
+  render() {
+    return null;
+  }
+}
 InitialLoadingScreen.propTypes = {
   initialLoading: PropTypes.bool,
   currentUser: PropTypes.shape({


### PR DESCRIPTION
### Summary

- Refactor initialLoading component from function to PureComponent

- Refactor screen template logic to use Pure Component

- Moved initial Loading like first Screen on StackNavigator

Examples
Login + Tab
![login tabs](https://user-images.githubusercontent.com/24418053/29090988-c1213aee-7c57-11e7-9047-89e60ee5eb1f.gif)

Login + Drawer
![login drawer](https://user-images.githubusercontent.com/24418053/29090995-c7ae73b8-7c57-11e7-9ad9-9f5c1b111123.gif)

Only home (Tabs )
![without tab](https://user-images.githubusercontent.com/24418053/29091007-d1a21f0a-7c57-11e7-8de9-9451d532d0f9.png)
