### PR TITLE
Avoid no-resolved modules for .android.js and .ios.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,5 +47,16 @@ module.exports = {
     "import/default": "off",
     "import/namespace": "off",
     "import/no-absolute-path": "error"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [
+          ".js",
+          ".android.js",
+          ".ios.js"
+        ]
+      }
+    }
   }
 };


### PR DESCRIPTION
## Summary
Added .android.js and .ios.js extensions to `.eslintrc.js`to avoid some unwanted no-resolved modules

### Description
I have encounter an issue when importing `react-native-image-resizer`. 
I got the eslint message `Unable to resolve path to module 'react-native-image-resizer'`
After looking for a solution I noticed the module didn't have an `index.js`, instead only `index.ios.js` and `index.android.js`. 
I have solved this issue adding these extensions to `.eslintrc.js`

### Related github issue:
https://github.com/lrettig/react-native-stripe/issues/24