### PR TITLE
Added option to push to another branch

### DIFF
--- a/generators/app/tasks/gitInitialization.js
+++ b/generators/app/tasks/gitInitialization.js
@@ -50,19 +50,52 @@ module.exports = function gitInitialization() {
                       { cwd: `${process.cwd()}/${this.projectName}` }
                     ],
                     context: this.options
-                  }).then(() =>
-                    // git push origin master
-                    runCommand({
-                      command: [
-                        'git',
-                        ['push', 'origin', 'master'],
-                        { cwd: `${process.cwd()}/${this.projectName}` }
-                      ],
-                      context: this.options
-                    }).then(() => {
-                      spinner.succeed('git ready');
+                  })
+                    .then(() => {
+                      spinner.stop();
+                      return this.prompt([
+                        {
+                          type: 'confirm',
+                          name: 'pushToMaster',
+                          message: 'Do you want to push to master?'
+                        }
+                      ]);
                     })
-                  );
+                    .then(({ pushToMaster }) => {
+                      spinner.start();
+                      if (!pushToMaster) {
+                        // git push origin kickoff
+                        return runCommand({
+                          command: [
+                            'git',
+                            ['checkout', '-b', 'kickoff'],
+                            { cwd: `${process.cwd()}/${this.projectName}` }
+                          ],
+                          context: this.options
+                        }).then(() => {
+                          runCommand({
+                            command: [
+                              'git',
+                              ['push', 'origin', 'kickoff'],
+                              { cwd: `${process.cwd()}/${this.projectName}` }
+                            ],
+                            context: this.options
+                          });
+                        });
+                      }
+                      // git push origin master
+                      return runCommand({
+                        command: [
+                          'git',
+                          ['push', 'origin', 'master'],
+                          { cwd: `${process.cwd()}/${this.projectName}` }
+                        ],
+                        context: this.options
+                      });
+                    })
+                    .then(() => {
+                      spinner.succeed('git ready');
+                    });
                 });
               }
             });


### PR DESCRIPTION
## Summary
Added option to push to another branch, instead of `master`. This is useful in cases when the user doesnt have permissions to push directly to `master`

## Screenshot
<img width="561" alt="screen shot 2018-01-04 at 20 44 08" src="https://user-images.githubusercontent.com/25931366/34589582-492e202a-f190-11e7-822d-cf8c9bb4b470.png">
