### PR TITLE
React navigation hotfixes

### DIFF
--- a/generators/app/tasks/installDependencies.js
+++ b/generators/app/tasks/installDependencies.js
@@ -8,6 +8,7 @@ const DEPENDENCIES = [
   'change-case',
   'lodash',
   'react-navigation',
+  'react-navigation-redux-helpers',
   'react-redux',
   'reactotron-apisauce',
   'reactotron-react-native',
@@ -75,9 +76,9 @@ function yarnInstall(projectName, deps, options, dev) {
     command: ['yarn', yarnArgs, { cwd: `${process.cwd()}/${projectName}` }],
     loadingMessage: `Fetching ${dev ? 'dev dependencies' : 'dependencies'}`,
     successMessage: `${dev ? 'Dev dependencies' : 'Dependencies'} ready!`,
-    failureMessage: `${
-      dev ? 'Dev dependencies' : 'Dependencies'
-    } installation failed. Turn verbose mode on for detailed logging`,
+    failureMessage: `${dev
+      ? 'Dev dependencies'
+      : 'Dependencies'} installation failed. Turn verbose mode on for detailed logging`,
     context: options
   });
 }

--- a/generators/app/templates/src/app/components/AppNavigator/index.js
+++ b/generators/app/templates/src/app/components/AppNavigator/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { NavigationActions, addNavigationHelpers } from 'react-navigation';
 import { createReduxBoundAddListener } from 'react-navigation-redux-helpers';
 
+import { ROOT } from '../../../constants/platform';
 import Navigator from '../../screens';
 
 class AppNavigator extends Component {
@@ -23,7 +24,7 @@ class AppNavigator extends Component {
     return true;
   };
 
-  addListener = createReduxBoundAddListener('root');
+  addListener = createReduxBoundAddListener(ROOT);
 
   render() {
     const { dispatch, nav, ...navigatorProps } = this.props;

--- a/generators/app/templates/src/app/components/AppNavigator/index.js
+++ b/generators/app/templates/src/app/components/AppNavigator/index.js
@@ -1,16 +1,43 @@
-import React from 'react';
-import { connect } from 'react-redux';
-import { addNavigationHelpers } from 'react-navigation';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { BackHandler } from 'react-native';
+import { connect } from 'react-redux';
+import { NavigationActions, addNavigationHelpers } from 'react-navigation';
+import { createReduxBoundAddListener } from 'react-navigation-redux-helpers';
 
 import Navigator from '../../screens';
 
-const AppNavigator = props => {
-  const { dispatch, nav, ...navigatorProps } = props;
-  return <Navigator {...navigatorProps} navigation={addNavigationHelpers({ dispatch, state: nav })} />;
-};
+class AppNavigator extends Component {
+  componentDidMount() {
+    BackHandler.addEventListener('hardwareBackPress', this.onBackPress);
+  }
+  componentWillUnmount() {
+    BackHandler.removeEventListener('hardwareBackPress', this.onBackPress);
+  }
+  onBackPress = () => {
+    const { dispatch, nav } = this.props;
+    if (nav.index === 0) {
+      return false;
+    }
+    dispatch(NavigationActions.back());
+    return true;
+  };
+
+  addListener = createReduxBoundAddListener('root');
+
+  render() {
+    const { dispatch, nav, ...navigatorProps } = this.props;
+    return (
+      <Navigator
+        {...navigatorProps}
+        navigation={addNavigationHelpers({ dispatch, state: nav, addListener: this.addListener })}
+      />
+    );
+  }
+}
 
 AppNavigator.propTypes = {
+  // TODO: Declare a correct PropType for nav
   nav: PropTypes.any // eslint-disable-line react/forbid-prop-types
 };
 

--- a/generators/app/templates/src/constants/platform.js
+++ b/generators/app/templates/src/constants/platform.js
@@ -1,5 +1,7 @@
 import { Platform, StatusBar, Dimensions } from 'react-native';
 
+export const ROOT = 'root';
+
 export const isAndroid = Platform.OS === 'android';
 export const isIos = Platform.OS === 'ios';
 

--- a/generators/app/templates/src/redux/store.ejs
+++ b/generators/app/templates/src/redux/store.ejs
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 import { isEqual } from 'lodash';
 import { createReactNavigationReduxMiddleware } from 'react-navigation-redux-helpers';
 
+import { ROOT } from '../constants/platform';
 import { getCurrentRouteName } from '../utils/navUtils';
 import Navigator from '../app/screens';
 
@@ -57,7 +58,7 @@ const middlewares = [];
 const enhancers = [];
 
 /* ------------- React Navigation Middleware ------------- */
-middlewares.push(createReactNavigationReduxMiddleware('root', state => state.nav));
+middlewares.push(createReactNavigationReduxMiddleware(ROOT, state => state.nav));
 
 /* ------------- Thunk Middleware ------------- */
 middlewares.push(thunk);

--- a/generators/app/templates/src/redux/store.ejs
+++ b/generators/app/templates/src/redux/store.ejs
@@ -2,6 +2,7 @@ import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import Reactotron from 'reactotron-react-native';
 import thunk from 'redux-thunk';
 import { isEqual } from 'lodash';
+import { createReactNavigationReduxMiddleware } from 'react-navigation-redux-helpers';
 
 import { getCurrentRouteName } from '../utils/navUtils';
 import Navigator from '../app/screens';
@@ -54,6 +55,9 @@ const reducers = combineReducers({
 
 const middlewares = [];
 const enhancers = [];
+
+/* ------------- React Navigation Middleware ------------- */
+middlewares.push(createReactNavigationReduxMiddleware('root', state => state.nav));
 
 /* ------------- Thunk Middleware ------------- */
 middlewares.push(thunk);


### PR DESCRIPTION
## Summary
* Added react-navigation-redux-helpers for redux integration with the last version of react-navigation
https://reactnavigation.org/docs/redux-integration.html

* Added back button handler for support back navigation with the back button for android devices

## Trello Card
https://trello.com/c/phEuvRxW/19-change-default-backbutton-behavior
https://trello.com/c/7mTMf6EN/84-add-react-navigation-redux-helpers-for-new-react-navigation-version