### PR TITLE
Fixed home path for templates generator

### DIFF
--- a/generators/app/tasks/appSetup/baseFilesTemplate.js
+++ b/generators/app/tasks/appSetup/baseFilesTemplate.js
@@ -95,8 +95,11 @@ module.exports = function baseFilesTemplate() {
   FILES.forEach(copyFile.bind(this));
 
   this.fs.copyTpl(
-    this.templatePath('src', 'app', 'screens', 'home', this.features.login ? 'index.js' : 'layout.ejs'),
-    this.destinationPath(this.projectName, 'src', 'app', 'screens', 'home', 'index.js'),
-    { projectName: this.projectName, features: this.features }
+    this.templatePath('src', 'app', 'screens', 'Home', this.features.login ? 'index.js' : 'layout.ejs'),
+    this.destinationPath(this.projectName, 'src', 'app', 'screens', 'Home', 'index.js'),
+    {
+      projectName: this.projectName,
+      features: this.features
+    }
   );
 };


### PR DESCRIPTION
### Summary
The template generatos searched in a path with home folder in minus, when this folder are writted in PascalCase `Home`. This pr fix this issue.
