### PR TITLE
Fixed redux navigation integration

### DIFF
--- a/generators/app/tasks/installDependencies.js
+++ b/generators/app/tasks/installDependencies.js
@@ -26,7 +26,6 @@ const DEPENDENCIES = [
 const DEV_DEPENDENCIES = [
   'babel-eslint',
   'babel-plugin-import-glob',
-  'babel-preset-react-native',
   'eslint',
   'eslint-config-airbnb',
   'eslint-config-prettier',

--- a/generators/app/templates/src/app/components/AppNavigator/index.js
+++ b/generators/app/templates/src/app/components/AppNavigator/index.js
@@ -34,8 +34,9 @@ class AppNavigator extends Component {
 }
 
 AppNavigator.propTypes = {
-  // TODO: Declare a correct PropType for nav
-  state: PropTypes.any // eslint-disable-line react/forbid-prop-types
+  state: PropTypes.shape({
+    index: PropTypes.number.isRequired
+  })
 };
 
 const mapStateToProps = store => ({ state: store.nav });

--- a/generators/app/templates/src/app/components/AppNavigator/index.js
+++ b/generators/app/templates/src/app/components/AppNavigator/index.js
@@ -3,47 +3,41 @@ import PropTypes from 'prop-types';
 import { BackHandler } from 'react-native';
 import { connect } from 'react-redux';
 import { NavigationActions } from 'react-navigation';
-import { createReduxBoundAddListener } from 'react-navigation-redux-helpers';
+import { reduxifyNavigator } from 'react-navigation-redux-helpers';
 
 import { ROOT } from '../../../constants/platform';
 import Navigator from '../../screens';
+
+const AppWithNavigationState = reduxifyNavigator(Navigator, ROOT);
 
 class AppNavigator extends Component {
   componentDidMount() {
     BackHandler.addEventListener('hardwareBackPress', this.onBackPress);
   }
+
   componentWillUnmount() {
     BackHandler.removeEventListener('hardwareBackPress', this.onBackPress);
   }
+
   onBackPress = () => {
-    const { dispatch, nav } = this.props;
-    if (nav.index === 0) {
+    const { dispatch, state } = this.props;
+    if (state.index === 0) {
       return false;
     }
     dispatch(NavigationActions.back());
     return true;
   };
 
-  addListener = createReduxBoundAddListener(ROOT);
-
   render() {
-    return (
-      <Navigator
-        navigation={{
-          dispatch: this.props.dispatch,
-          state: this.props.nav,
-          addListener: this.addListener
-        }}
-      />
-    );
+    return <AppWithNavigationState {...this.props} />;
   }
 }
 
 AppNavigator.propTypes = {
   // TODO: Declare a correct PropType for nav
-  nav: PropTypes.any // eslint-disable-line react/forbid-prop-types
+  state: PropTypes.any // eslint-disable-line react/forbid-prop-types
 };
 
-const mapStateToProps = store => ({ nav: store.nav });
+const mapStateToProps = store => ({ state: store.nav });
 
 export default connect(mapStateToProps)(AppNavigator);

--- a/generators/app/templates/src/app/screens.ejs
+++ b/generators/app/templates/src/app/screens.ejs
@@ -7,7 +7,7 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 <%_ } _%>
-import { <% if (features.tabs) { %>TabNavigator, <% } %>StackNavigator } from 'react-navigation';
+import { <% if (features.tabs) { %>createBottomTabNavigator, <% } %>createStackNavigator } from 'react-navigation';
 
 import * as Routes from '../constants/routes';
 import { stackNavConfig, screensNavOptions, <% if (features.tabs) { %>tabNavConfig<% } %> } from '../config/navigation';
@@ -49,7 +49,7 @@ const InitialLoadingScreenContainer = connect(loadingScreenMapStateToProps)(Init
 // ------------------ Initial loading screen end
 
 <%_ } _%>
-export default StackNavigator(
+export default createStackNavigator(
   {
     <%_ if (features.login) { _%>
     [Routes.InitialLoading]: {
@@ -63,7 +63,7 @@ export default StackNavigator(
     <%_ } _%>
     [Routes.Home]: {
       <%_ if (features.tabs) { _%>
-      screen: TabNavigator(
+      screen: createBottomTabNavigator(
         {
           [Routes.Tab1]: {
             screen: Home,


### PR DESCRIPTION
* Fixed redux navigation integration
* Replaced TabNavigator and StackNavigator with new creators
* Removed `babel-preset-react-native` because npm is installing an older version. It should install +5 but its using 4.0, which is incompatible with Babel 7. (By removing it, npm adds the last version to the package.json file)