### PR TITLE
Change componentWillMount to componentDidMount

### DIFF
--- a/generators/app/templates/src/app/index.ejs
+++ b/generators/app/templates/src/app/index.ejs
@@ -28,7 +28,7 @@ import AppNavigator from './components/AppNavigator';
 <%_ } _%>
 
 class App extends Component {
-  componentWillMount() {
+  componentDidMount() {
     <%_ if(features.pushnotifications) { _%>
     configPushNotifications(this.props.dispatch);
     alertIfHuaweiDevice();


### PR DESCRIPTION
## Summary

* Change componentWillMount to componentDidMount, since willMount is deprecated
* fixes a crash with HuaweiProtectedApps, when reopening the app after closing it with the back button.