### PR TITLE
R-R ConfigureMergeState

### DIFF
--- a/generators/app/templates/src/redux/store.ejs
+++ b/generators/app/templates/src/redux/store.ejs
@@ -1,11 +1,11 @@
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import Reactotron from 'reactotron-react-native';
 import thunk from 'redux-thunk';
-import { 
+import {
   createReactNavigationReduxMiddleware,
   createNavigationReducer
 } from 'react-navigation-redux-helpers';
-import { fetchMiddleware } from 'redux-recompose';
+import { fetchMiddleware, configureMergeState } from 'redux-recompose';
 
 import { ROOT } from '../constants/platform';
 import Navigator from '../app/screens';
@@ -26,6 +26,8 @@ import drawer from './drawer/reducer';
 
 <%_ } _%>
 const nav = createNavigationReducer(Navigator);
+
+configureMergeState((state, diff) => state.merge(diff));
 
 const reducers = combineReducers({
   <%_ if(features.pushnotifications) { _%>


### PR DESCRIPTION
## Summary
* Added configureMergeState for redux-recompose to redux store. This solves the error `state.merge is undefined` when we use Immutable in reducers.

## Trello Card
https://trello.com/c/140XfhUm/89-configurar-state-merge-de-redux-recompose