### PR TITLE
Track async storage and attach Reactotron to the console object

### DIFF
--- a/generators/app/templates/src/config/ReactotronConfig.ejs
+++ b/generators/app/templates/src/config/ReactotronConfig.ejs
@@ -1,5 +1,5 @@
 import Immutable from 'seamless-immutable';
-import Reactotron, { trackGlobalErrors } from 'reactotron-react-native';
+import Reactotron, { trackGlobalErrors, asyncStorage } from 'reactotron-react-native';
 import apisaucePlugin from 'reactotron-apisauce';
 import { reactotronRedux } from 'reactotron-redux';
 import { NativeModules } from 'react-native';
@@ -12,5 +12,8 @@ if (__DEV__) {
     .use(trackGlobalErrors())
     .use(apisaucePlugin())
     .use(reactotronRedux({ onRestore: state => Immutable(state) }))
+    .use(asyncStorage())
     .connect();
+  // eslint-disable-next-line no-console
+  console.tron = Reactotron;
 }


### PR DESCRIPTION
### Summary
* Track async storage with Reactotron
https://github.com/infinitered/reactotron/blob/master/docs/plugin-async-storage.md
* Attach Reactotron to the console object to allow us to log through it
https://github.com/infinitered/reactotron/blob/master/docs/tips.md#piggybacking-on-console