### PR TITLE
Activate Hermes by default 

### DIFF
--- a/generators/app/tasks/appSetup/androidProjectSetup.js
+++ b/generators/app/tasks/appSetup/androidProjectSetup.js
@@ -5,6 +5,10 @@ function addDotenvPluginAndRNScreen() {
     'apply plugin: "com.android.application"\napply from: project(\':react-native-config\').projectDir.getPath() + "/dotenv.gradle"'
   );
   updatedBuildGradleContent = updatedBuildGradleContent.replace(
+    'enableHermes: false,',
+    'enableHermes: true,'
+  );
+  updatedBuildGradleContent = updatedBuildGradleContent.replace(
     'if (enableHermes) {',
     "implementation 'androidx.appcompat:appcompat:1.1.0-rc01'\n\timplementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'\n\n\tif (enableHermes) {"
   );


### PR DESCRIPTION
## Summary

Hey guys and girls! I just changed one line of code at the `android/app/build.gradle`. Now when the project it's generated the `enableHermes` is `true` instead of `false`.

Hope you enjoy your stay! ☮️ 

PS: 
```
if (questions) {
slack(Matt);
} else {
pr.approve();
}
```

## Screenshots
![Captura de Pantalla 2019-09-30 a la(s) 17 24 31](https://user-images.githubusercontent.com/44204622/65914026-303f2900-e3a7-11e9-830a-99e887835db5.png)


## Trello Card

https://trello.com/c/wI2jYfTT/131-activar-hermes-por-defecto
