### PR TITLE
Change snapshot library

### DIFF
--- a/generators/app/templates/__tests__/screens/Login/testLoginScreen.js
+++ b/generators/app/templates/__tests__/screens/Login/testLoginScreen.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import CustomTextInput from '@components/CustomTextInput';
 import CustomButton from '@components/CustomButton';
 import { Login } from '@app/screens/Login/layout';
+import renderer from 'react-test-renderer';
 
 describe('<Login />', () => {
   test('without errors', () => {
@@ -13,7 +14,7 @@ describe('<Login />', () => {
   });
   test('Login Snapshot', () => {
     const onLogin = jest.fn();
-    const wrapper = shallow(<Login onLogin={onLogin} />);
-    expect(toJson(wrapper)).toMatchSnapshot();
+    const tree = renderer.create(<Login onLogin={onLogin} />).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/generators/app/templates/__tests__/screens/Login/testLoginScreen.js
+++ b/generators/app/templates/__tests__/screens/Login/testLoginScreen.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import CustomTextInput from '@components/CustomTextInput';
 import CustomButton from '@components/CustomButton';
 import { Login } from '@app/screens/Login/layout';


### PR DESCRIPTION
## Summary

We decided to use react-test-renderer to build snapshots, so in this pr I've replaced shallow (Enzyme) for create (react-test-renderer)

