### PR TITLE
[fix] temporary added again the lane to change the app id

### DIFF
--- a/generators/app/tasks/configureFastlane.js
+++ b/generators/app/tasks/configureFastlane.js
@@ -38,5 +38,22 @@ module.exports = function configureFastlane() {
         successMessage: 'Delete Success!',
         context: this.options
       })
-    );
+    )
+    .then(() => {
+      const fastlaneFastfile = this.fs.read(`${this.projectName}/ios/fastlane/Fastfile`);
+      const updateFastlaneFastfile = fastlaneFastfile.replace(
+        "import 'Fastfile.private'",
+        `import 'Fastfile.private'\n
+          desc "Update Bundle Identifier"
+          lane :update_bundle_identifier do |options|
+          project_name = options[:project_name]
+          update_app_identifier(
+            xcodeproj: "./#{project_name}.xcodeproj", # Optional path to xcodeproj, will use the first .xcodeproj if not set
+            plist_path: "./#{project_name}/Info.plist", # Path to info plist file, relative to xcodeproj
+            app_identifier: "#{options[:bundle_identifier]}" # The App Identifier
+          )
+        end`
+      );
+      this.fs.write(`${this.projectName}/ios/fastlane/Fastfile`, updateFastlaneFastfile);
+    });
 };


### PR DESCRIPTION
## Summary
Added  again the lane `update_bundle_identifier` until the PR of multiple environments is merged and the build configurations are correctly changed

## Screenshots
Generated a base project with no errors:
<img width="646" alt="Screen Shot 2020-04-03 at 18 09 23" src="https://user-images.githubusercontent.com/25931366/78405180-50f66e80-75d6-11ea-814f-5506e0e3c1f2.png">

