### PR TITLE
the dependency of react native eslint was removed

### DIFF
--- a/generators/app/tasks/configuringTasks/installDependencies.js
+++ b/generators/app/tasks/configuringTasks/installDependencies.js
@@ -35,7 +35,6 @@ const DEPENDENCIES = [
 ];
 
 const DEV_DEPENDENCIES = [
-  '@react-native-community/eslint-config',
   '@testing-library/jest-native',
   '@types/jest',
   '@types/react-native',


### PR DESCRIPTION
## Summary

The linter failed when starting a new project, to fix it the dependency of @react-native-community/eslint-config was removed. 
Now this dependency is taken together with the 'react native init'

## Screenshots
Error
<img width="566" alt="Screen Shot 2021-07-07 at 18 48 46" src="https://user-images.githubusercontent.com/38305799/124833051-f758be80-df53-11eb-9702-422b4cdff36c.png">

Fixed
<img width="565" alt="Screen Shot 2021-07-07 at 18 49 08" src="https://user-images.githubusercontent.com/38305799/124833080-0475ad80-df54-11eb-8167-4a88018a8902.png">

