### PR TITLE
delete a comment from navigation 6

### DIFF
--- a/generators/app/templates/src/config/navigation.ejs
+++ b/generators/app/templates/src/config/navigation.ejs
@@ -42,11 +42,6 @@ const defaultTabNavOptions = {
 }
 
 export const tabNavConfig = {
-  // TODO: Change them to your need
-  // tabBarOptions: {
-  //   activeTintColor: 'blue',
-  //   inactiveTintColor: 'gray',
-  // }
   screenOptions: defaultTabNavOptions
 };
 <%_ } _%>


### PR DESCRIPTION
## Summary

Update navigation from 5 to 6.

The tabBarOptions prop was removed and the options from there were moved to screen's options instead. This makes them configurable on a per screen basis.

## Screenshots

![Screen Shot 2021-12-27 at 7 23 02 AM](https://user-images.githubusercontent.com/75996952/147666423-ef94eb3e-a988-4661-bb8c-5274bad4ba04.png)

## Trello Card

[Actualizar implementación de React Navigation para la v6](https://trello.com/c/I27uyWF7/218-actualizar-implementaci%C3%B3n-de-react-navigation-para-la-v6
)